### PR TITLE
provide credit for threat dragon artwork

### DIFF
--- a/projects/threat-dragon/README.md
+++ b/projects/threat-dragon/README.md
@@ -5,3 +5,11 @@ Cupcake is the name of the Threat Dragon dragon, in various formats:
 * gif
 * icons
 * svg artworks
+
+We are very grateful to the talented artist [DЯΣΛMƧVΣЯƧΣ](https://linktr.ee/dreamsverse) who created the artwork for Cupcake,
+the Threat Dragon logo.
+
+DЯΣΛMƧVΣЯƧΣ has allowed use of the [original artwork](https://www.deviantart.com/thelonelyqueen/art/HW-Lil-Baby-Dragon-Lineart-300502156)
+on condition that it used only for 'not for profit' purposes - perfect for the OWASP open source project.
+
+Cupcake has a birthday as well: DЯΣΛMƧVΣЯƧΣ uploaded the original artwork on 7th May 2012.


### PR DESCRIPTION
This pull request gives credit for the Threat Dragon artwork to the original artist, who has given written permission for us to use this artwork if it is not-for-profit.

:information_source: Please make sure you have read and are [adhering to the rules](https://github.com/OWASP/owasp-swag#rules) ([:uk:](https://github.com/OWASP/owasp-swag#rules)/[:jp:](https://github.com/OWASP/owasp-swag/blob/master/README_JP.md#%E3%83%AB%E3%83%BC%E3%83%AB)) for additions to this repository!
